### PR TITLE
Correct deparsing of preproccessors within structs

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -329,10 +329,16 @@ function deparse_precision(node) {
 }
 
 function deparse_preprocessor(node) {
+  var level = ws.level
+
+  ws.level = 0
+
   if(output[output.length - 1] !== '\n')
     output.push(ws.required('\n'))
   output.push(node.token.data)
   output.push(ws.required('\n'))
+
+  ws.level = level
 }
 
 function deparse_return(node) {
@@ -403,7 +409,9 @@ function deparse_struct(node) {
 
   for(var i = 1, len = node.children.length; i < len; ++i) {
     deparse(node.children[i])
-    output.push(';')
+    if(node.children[i].type !== 'preprocessor') {
+      output.push(';')
+    }
     if(i !== len_minus_one) {
       output.push(ws.optional('\n'))
     }


### PR DESCRIPTION
- Ensures that semicolons are not added after each directive
- Ignore indentation levels when deparsing directives

Thanks! :)
