### PR TITLE
Add deparseString to allow deparsing within browser

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,7 @@
-module.exports = deparse_stream
+module.exports = {
+  deparse: deparse,
+  deparseString: deparseString
+};
 
 var through = require('through')
   , language = require('cssauron-glsl')
@@ -80,6 +83,14 @@ function deparse_stream(with_whitespace, indent) {
   function end() {
     stream.queue(null)
   }
+}
+
+function deparseString(n, with_whitespace, indent) {
+  output.length = 0;
+  with_whitespace = with_whitespace === undefined ? true : with_whitespace;
+  ws = new WSManager(with_whitespace, indent || '  ');
+  deparse(n);
+  return output.join('');
 }
 
 function deparse(n) {
@@ -376,7 +387,7 @@ function deparse_stmt(node) {
 }
 
 function deparse_stmtlist(node) {
-  var has_parent = node.parent !== null
+  var has_parent = node.parent !== null && node.parent !== undefined;
  
   if(has_parent) {
     output.push('{')


### PR DESCRIPTION
I want to use `glsl-deparser` in the browser where there is no native implementation of `stream` (as far as I can tell). Therefore I propose that `glsl-deparser` expose an alternative direct-to-string function (similar to what `glsl-parse` and `glsl-tokenize` do).

This change was the minimal diff to get things working in my project.